### PR TITLE
De-linkify "Authors" breadcrumb

### DIFF
--- a/thedatalab/frontend/templates/author.html
+++ b/thedatalab/frontend/templates/author.html
@@ -8,7 +8,7 @@
 				<ul class="breadcrumbs" typeof="BreadcrumbList">
 					<li><a href="/">Home</a> &gt; </li> 
                     {% block breadcrumb %}
-					<li> <a href="../">Authors</a> &gt; </li>
+					<li> Authors &gt; </li>
                     {% endblock %}
 				</ul>		
 				<h1>{{ author.name }}</h1>


### PR DESCRIPTION
* currently goes to a 404
* maybe we don't need that page anyway