### PR TITLE
Require a trailing slash for page urls

### DIFF
--- a/thedatalab/urls.py
+++ b/thedatalab/urls.py
@@ -68,7 +68,7 @@ urlpatterns = [
 
     path('', views.home_view, name='home'),
 
-    re_path(r'^(.*)$', views.page_view, name='page_view'),
+    re_path(r'^(.*)/$', views.page_view, name='page_view'),
 ]
 
 


### PR DESCRIPTION
* we should roll out nginx rules to rewrite urls without trailing slashes at the same time, to avoid breaking things
* part of https://github.com/ebmdatalab/thedatalab/issues/54